### PR TITLE
Wrap Paper with UILink to push to new tab.

### DIFF
--- a/react-ui/src/components/mycourse/CourseCard.jsx
+++ b/react-ui/src/components/mycourse/CourseCard.jsx
@@ -60,24 +60,24 @@ const CourseCard = ({
 
   return (
     <Link to={`/courses/${subject}/${catalogNumber}`} target="_blank" style={{ textDecoration: 'none' }}>
-    <Paper
-      zDepth={ 1 }
-      style={ styles.container(highlightBackground) }
-    >
-      <div
-        ref={ provided.innerRef }
-        { ...provided.draggableProps }
-        { ...provided.dragHandleProps }
-        style={ getItemStyle(
-          snapshot.isDragging,
-          isPrereq,
-          provided.draggableProps.style,
-          highlightBackground,
-        ) }
+      <Paper
+        zDepth={ 1 }
+        style={ styles.container(highlightBackground) }
       >
-        { `${subject} ${catalogNumber}` }
-      </div>
-    </Paper>
+        <div
+          ref={ provided.innerRef }
+          { ...provided.draggableProps }
+          { ...provided.dragHandleProps }
+          style={ getItemStyle(
+            snapshot.isDragging,
+            isPrereq,
+            provided.draggableProps.style,
+            highlightBackground,
+          ) }
+        >
+          { `${subject} ${catalogNumber}` }
+        </div>
+      </Paper>
     </Link>
   );
 }

--- a/react-ui/src/components/mycourse/CourseCard.jsx
+++ b/react-ui/src/components/mycourse/CourseCard.jsx
@@ -59,7 +59,7 @@ const CourseCard = ({
   const isPrereq = isInPrereqs(subject, catalogNumber, courseCardPrereqs);
 
   return (
-    <Link to={`/courses/${subject}/${catalogNumber}`} target="_blank" style={{ textDecoration: 'none' }}>
+    <Link to={ `/courses/${subject}/${catalogNumber}` } target="_blank" style={{ textDecoration: 'none' }}>
       <Paper
         zDepth={ 1 }
         style={ styles.container(highlightBackground) }

--- a/react-ui/src/components/mycourse/CourseCard.jsx
+++ b/react-ui/src/components/mycourse/CourseCard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
+import { withRouter, Link } from 'react-router-dom';
 import Paper from 'material-ui/Paper';
 import {
   yellow,
@@ -59,9 +59,9 @@ const CourseCard = ({
   const isPrereq = isInPrereqs(subject, catalogNumber, courseCardPrereqs);
 
   return (
+    <Link to={`/courses/${subject}/${catalogNumber}`} target="_blank" style={{ textDecoration: 'none' }}>
     <Paper
       zDepth={ 1 }
-      onClick={ () => history.push(`/courses/${subject}/${catalogNumber}`) }
       style={ styles.container(highlightBackground) }
     >
       <div
@@ -78,6 +78,7 @@ const CourseCard = ({
         { `${subject} ${catalogNumber}` }
       </div>
     </Paper>
+    </Link>
   );
 }
 


### PR DESCRIPTION
## Description
On click of a course on the `my courses` page, it will take you to a new tab. Wrapped the page with a UILink as there was no way for `history.push` to push to a new tab.

Fixes # (issue)
https://github.com/theRoughCode/WatsMyMajor/issues/86
## Type of change

- [x] New feature (non-breaking change which adds functionality)

### Tests:

- [x] Added courses, Link worked, 
- [x]  clear courses, the link still works

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
