### PR TITLE
Include course titles beside requisites and courses in "My Courses"

### DIFF
--- a/react-ui/src/components/courselist/CourseViewContainer.jsx
+++ b/react-ui/src/components/courselist/CourseViewContainer.jsx
@@ -86,17 +86,6 @@ const getCourseClasses = async (subject, catalogNumber, term) => {
   return await response.json();
 };
 
-// Formats postreqs obj into arr
-const formatPostreqs = (postreqs) => {
-  const formatted = [];
-  for (let subject in postreqs) {
-    for (let catalogNumber in postreqs[subject]) {
-      formatted.push({ subject, catalogNumber });
-    }
-  }
-  return formatted;
-};
-
 class CourseViewContainer extends Component {
 
   static propTypes = {
@@ -244,7 +233,7 @@ class CourseViewContainer extends Component {
         antireqs,
         coreqs,
         prereqs,
-        postreqs: formatPostreqs(postreqs),
+        postreqs,
       };
 
       const eligible = canTakeCourse(this.props.myCourses, prereqs, coreqs, antireqs);

--- a/react-ui/src/components/courselist/content/ChooseReqs.jsx
+++ b/react-ui/src/components/courselist/content/ChooseReqs.jsx
@@ -20,7 +20,7 @@ const styles = {
   },
 };
 
-const Prereqs = ({ choose, reqs }) => (
+const ChooseReqs = ({ choose, reqs }) => (
   <div style={ styles.container }>
     <span style={ styles.choose }>{ `Choose ${choose} of:` }</span>
     <div style={ styles.reqs }>
@@ -29,9 +29,9 @@ const Prereqs = ({ choose, reqs }) => (
   </div>
 );
 
-Prereqs.propTypes = {
+ChooseReqs.propTypes = {
   choose: PropTypes.number.isRequired,
   reqs: PropTypes.array.isRequired
 };
 
-export default Prereqs;
+export default ChooseReqs;

--- a/react-ui/src/components/courselist/content/CourseRequisites.jsx
+++ b/react-ui/src/components/courselist/content/CourseRequisites.jsx
@@ -5,7 +5,7 @@ import Paper from 'material-ui/Paper';
 import { Tabs, Tab } from 'material-ui/Tabs';
 import SwipeableViews from 'react-swipeable-views';
 import { hasTakenCourse } from '../../../utils/courses';
-import Prereqs from './Prereqs';
+import ChooseReqs from './ChooseReqs';
 import { green, mustard, purple } from '../../../constants/Colours';
 
 const styles = {
@@ -32,14 +32,19 @@ const styles = {
     padding: 10,
     display: 'flex',
     flexDirection: 'column',
+    overflowX: 'hidden',
   },
   reqs: (isSelected) => ({
+    width: '100%',
     color: (isSelected) ? green : 'inherit',
     textDecoration: 'none',
     padding: 1,
     paddingLeft: 10,
     textAlign: 'left',
     cursor: 'pointer',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   }),
 };
 
@@ -82,7 +87,7 @@ class CourseRequisites extends Component {
     if (typeof course === "string") return course;
 
     const { myCourses } = this.props;
-    const { subject, catalogNumber } = course;
+    const { subject, catalogNumber, title } = course;
     const hasTaken = hasTakenCourse(subject, catalogNumber, myCourses);
 
     return (
@@ -94,6 +99,7 @@ class CourseRequisites extends Component {
       >
         { `${subject} ${catalogNumber}` }
         { hasTakenCourse(subject, catalogNumber, myCourses) ? ' ✔' : '' }
+        <span style={{ fontSize: 12 }}>&ensp;<i>{ title }</i></span>
       </a>
     )
   }
@@ -113,7 +119,7 @@ class CourseRequisites extends Component {
       if (requisites.reqs == null) return [];
       const newReqsArr = requisites.reqs.map(this.formatReqs);
       return [
-        <Prereqs
+        <ChooseReqs
           key={ 0 }
           choose={ requisites.choose }
           reqs={ newReqsArr }

--- a/react-ui/src/components/mycourse/CourseCard.jsx
+++ b/react-ui/src/components/mycourse/CourseCard.jsx
@@ -53,7 +53,7 @@ const CourseCard = ({
   highlightBackground,
   history
 }) => {
-  const { subject, catalogNumber } = course;
+  const { subject, catalogNumber, title } = course;
 
   // Mark this card as selected if is a prereq of dragged card
   const isPrereq = isInPrereqs(subject, catalogNumber, courseCardPrereqs);
@@ -74,6 +74,8 @@ const CourseCard = ({
             provided.draggableProps.style,
             highlightBackground,
           ) }
+          data-tip={ title }
+          data-for="course-card-title"
         >
           { `${subject} ${catalogNumber}` }
         </div>

--- a/react-ui/src/components/schedule/CalendarContainer.jsx
+++ b/react-ui/src/components/schedule/CalendarContainer.jsx
@@ -80,6 +80,7 @@ const parseCourses = (courses) => {
   const classesArr = [];
 
   courses.forEach(({ subject, catalogNumber, classes }) => {
+    if (!classes) return;
     const colour = RandomColour({ luminosity: 'dark' });
     Object.entries(classes).forEach(arr => {
       const type = arr[0];

--- a/server/core/courses.js
+++ b/server/core/courses.js
@@ -1,6 +1,7 @@
 const fuzzy = require('fuzzy');
 const requisites = require('./requisites');
 const coursesDB = require('../database/courses');
+const courseListDB = require('../database/courseList');
 const courseRatingsDB = require('../database/courseRatings');
 
 // Extractors for fuzzy searching
@@ -18,8 +19,7 @@ const containsCourse = ({ subject, catalogNumber }, arr) => {
 // Searches courses with query and a specified number of results to return
 async function searchCourses(query, limit) {
   try {
-    const { err, courses } = await coursesDB.getCoursesForSearch();
-    if (err) return { err, result: null };
+    const courses = await courseListDB.getCourseList();
 
     // If query length is <= 5, only search by subject and catalogNumber.
     // Else include title in search as well.
@@ -107,7 +107,7 @@ async function getCourseInfo(subject, catalogNumber) {
   let rating = null;
   ({ err, rating } = await courseRatingsDB.getCourseRatings(subject, catalogNumber));
   if (err) return { err, info: null };
-  
+
   return {
     err: null,
     info: {

--- a/server/core/requisites.js
+++ b/server/core/requisites.js
@@ -20,7 +20,7 @@ const fillCourseTitles = async (coursesArr) => {
       const { subject, catalogNumber } = course;
       const { err, title } = await courseListDB.getCourseTitle(subject, catalogNumber);
       if (err) {
-        console.err(err);
+        console.error(err);
         return {};
       }
       return { subject, catalogNumber, title };
@@ -28,7 +28,7 @@ const fillCourseTitles = async (coursesArr) => {
       let { choose, reqs } = course;
       reqs = await fillCourseTitles(reqs);
       return { choose, reqs };
-    } else console.err('Should not happen', course);
+    } else console.error('Should not happen', course);
   }));
 }
 

--- a/server/core/requisites.js
+++ b/server/core/requisites.js
@@ -1,0 +1,73 @@
+const requisitesDB = require('../database/requisites');
+const courseListDB = require('../database/courseList');
+
+// Formats postreqs obj into arr
+const formatPostreqs = (postreqs) => {
+  const formatted = [];
+  for (let subject in postreqs) {
+    for (let catalogNumber in postreqs[subject]) {
+      formatted.push({ subject, catalogNumber });
+    }
+  }
+  return formatted;
+};
+
+// Fills course array with titles
+const fillCourseTitles = async (coursesArr) => {
+  if (!coursesArr) return coursesArr;
+  return await Promise.all(coursesArr.map(async (course) => {
+    if (course.hasOwnProperty("subject")) {
+      const { subject, catalogNumber } = course;
+      const { err, title } = await courseListDB.getCourseTitle(subject, catalogNumber);
+      if (err) {
+        console.err(err);
+        return {};
+      }
+      return { subject, catalogNumber, title };
+    } else if (course.hasOwnProperty("choose")) {
+      let { choose, reqs } = course;
+      reqs = await fillCourseTitles(reqs);
+      return { choose, reqs };
+    } else console.err('Should not happen', course);
+  }));
+}
+
+// Returns reqs, but formatted with course titles.
+// Used with getCourseInfo
+async function getFormattedReqs(subject, catalogNumber) {
+  const { err, reqs } = await requisitesDB.getRequisites(subject, catalogNumber);
+  if (err || reqs == null) return {
+    err,
+    reqs: { prereqs: {}, coreqs: [], antireqs: [], postreqs: [] },
+  };
+
+  let prereqs = reqs.prereqs;
+  if (prereqs == null) prereqs = {};
+  else prereqs.reqs = await fillCourseTitles(prereqs.reqs);
+
+  let coreqs = reqs.coreqs;
+  if (coreqs == null) coreqs = [];
+  else coreqs = await fillCourseTitles(coreqs);
+
+  let antireqs = reqs.antireqs;
+  if (antireqs == null) antireqs = [];
+  else antireqs = await fillCourseTitles(antireqs);
+
+  let postreqs = reqs.postreqs
+  if (postreqs == null) postreqs = {};
+  else postreqs = await fillCourseTitles(formatPostreqs(postreqs));
+
+  return {
+    err: null,
+    reqs: {
+      prereqs,
+      coreqs,
+      postreqs,
+      antireqs,
+    },
+  };
+}
+
+module.exports = {
+  getFormattedReqs,
+};

--- a/server/core/requisites.js
+++ b/server/core/requisites.js
@@ -54,7 +54,7 @@ async function getFormattedReqs(subject, catalogNumber) {
   else antireqs = await fillCourseTitles(antireqs);
 
   let postreqs = reqs.postreqs
-  if (postreqs == null) postreqs = {};
+  if (postreqs == null) postreqs = [];
   else postreqs = await fillCourseTitles(formatPostreqs(postreqs));
 
   return {

--- a/server/core/update.js
+++ b/server/core/update.js
@@ -25,8 +25,8 @@ function updateCourseList() {
     waterloo.getCourses(async function(err, data) {
       if (err) return resolve(err);
 
-      await Promise.all(data.map(async ({ subject, catalog_number }) => {
-        await courseListDB.setCourse(subject, catalog_number);
+      await Promise.all(data.map(async ({ subject, catalog_number, title }) => {
+        await courseListDB.setCourse(subject, catalog_number, title);
       }));
       resolve(null);
     });

--- a/server/core/utils.js
+++ b/server/core/utils.js
@@ -158,6 +158,7 @@ function flattenPrereqs(prereqs) {
 
 // Set prereqs for input courses
 async function setCoursesPrereqs(courses) {
+  if (!courses) return [];
   return await Promise.all(courses.map(async function(course) {
     let { subject, catalogNumber, prereqs } = course;
     if (prereqs != null) return course;

--- a/server/database/courseList.js
+++ b/server/database/courseList.js
@@ -15,10 +15,10 @@ const { courseListRef } = require('./index');
 
 // Set a course
 // TODO: Use title instead and then use this to search
-function setCourse(subject, catalogNumber) {
+function setCourse(subject, catalogNumber, title) {
   return courseListRef
     .child(`${subject}/${catalogNumber}`)
-    .set(true);
+    .set(title);
 }
 
 
@@ -28,6 +28,20 @@ function setCourse(subject, catalogNumber) {
  *													*
  ****************************/
 
+// Returns course name
+async function getCourseTitle(subject, catalogNumber) {
+  try {
+    const snapshot = await courseListRef
+      .child(`${subject}/${catalogNumber}`)
+      .once('value');
+    const title = await snapshot.val();
+    return { err: null, title };
+  } catch (err) {
+    console.error(err);
+    return { err: err.message, title: null };
+  }
+}
+
 // Returns array of courses: { subject, catalogNumber }
 async function getCourseList() {
   const courseList = [];
@@ -36,7 +50,7 @@ async function getCourseList() {
     const subject = subjectSnapshot.key;
     subjectSnapshot.forEach((catalogNumberSnapshot) => {
       const catalogNumber = catalogNumberSnapshot.key;
-      courseList.push({ subject, catalogNumber });
+      courseList.push({ subject, catalogNumber, title: catalogNumberSnapshot.val() });
     });
   });
   return courseList;
@@ -44,5 +58,6 @@ async function getCourseList() {
 
 module.exports = {
   setCourse,
+  getCourseTitle,
   getCourseList,
 };

--- a/server/database/courseList.js
+++ b/server/database/courseList.js
@@ -6,6 +6,8 @@ const { courseListRef } = require('./index');
  *  to populate their data.
  */
 
+let cachedCourseList = [];
+let valid = false;
 
 /****************************
  *													*
@@ -14,8 +16,8 @@ const { courseListRef } = require('./index');
  ****************************/
 
 // Set a course
-// TODO: Use title instead and then use this to search
 function setCourse(subject, catalogNumber, title) {
+  valid = false;
   return courseListRef
     .child(`${subject}/${catalogNumber}`)
     .set(title);
@@ -44,6 +46,8 @@ async function getCourseTitle(subject, catalogNumber) {
 
 // Returns array of courses: { subject, catalogNumber }
 async function getCourseList() {
+  if (valid) return cachedCourseList;  // use cached version if valid flag is true
+
   const courseList = [];
   const snapshot = await courseListRef.once('value');
   snapshot.forEach((subjectSnapshot) => {
@@ -53,6 +57,8 @@ async function getCourseList() {
       courseList.push({ subject, catalogNumber, title: catalogNumberSnapshot.val() });
     });
   });
+  cachedCourseList = courseList.slice();
+  valid = true;
   return courseList;
 }
 

--- a/server/database/courses.js
+++ b/server/database/courses.js
@@ -1,15 +1,5 @@
 const { coursesRef } = require('./index');
 
-const coursesForSearch = [];
-
-/* A list of the courses available
-    {
-      subject: {
-        catalogNumber: title
-      }
-    }
-*/
-
 /****************************
  *                          *
  *      S E T T E R S       *
@@ -26,29 +16,6 @@ function setCourseInfo(subject, catalogNumber, info) {
  *      G E T T E R S       *
  *                          *
  ****************************/
-
-// Retrieves all courses as strings to be used for search
-async function getCoursesForSearch() {
-  // Get cached courses if cached
-  if (coursesForSearch.length > 0) return { err: null, courses: coursesForSearch };
-
-  try {
-    const snapshot = await coursesRef.once('value');
-    const courses = snapshot.val();
-    const subjects = Object.keys(courses);
-    subjects.forEach(subject => {
-      const catalogNumbers = Object.keys(courses[subject]);
-      catalogNumbers.forEach(catalogNumber => {
-        const { title } = courses[subject][catalogNumber];
-        coursesForSearch.push({ subject, catalogNumber, title });
-      });
-    });
-    return { err: null, courses: coursesForSearch };
-  } catch (err) {
-    console.error(err);
-    return { err, courses: null };
-  }
-}
 
 // Returns course information
 // { err, course }
@@ -67,6 +34,5 @@ async function getCourseInfo(subject, catalogNumber) {
 
 module.exports = {
   setCourseInfo,
-  getCoursesForSearch,
   getCourseInfo,
 };

--- a/server/routes/courses.js
+++ b/server/routes/courses.js
@@ -2,8 +2,6 @@ const CoursesRouter = require('express').Router();
 const courses = require('../core/courses');
 const courseClassesDB = require('../database/classes');
 const courseListDB = require('../database/courseList');
-const courseRatingsDB = require('../database/courseRatings');
-const requisitesDB = require('../database/requisites');
 
 // Get search results for query string and max number of results
 CoursesRouter.get('/query/:query/:num', async function(req, res) {

--- a/server/routes/courses.js
+++ b/server/routes/courses.js
@@ -1,6 +1,7 @@
 const CoursesRouter = require('express').Router();
 const courses = require('../core/courses');
 const courseClassesDB = require('../database/classes');
+const courseListDB = require('../database/courseList');
 const courseRatingsDB = require('../database/courseRatings');
 const requisitesDB = require('../database/requisites');
 
@@ -14,55 +15,31 @@ CoursesRouter.get('/query/:query/:num', async function(req, res) {
   else res.json(result);
 });
 
+// Gets list of all courses
+CoursesRouter.get('/all', async function (req, res) {
+  const courseList = await courseListDB.getCourseList();
+  res.json(courseList);
+});
+
+// Gets course title
+CoursesRouter.get('/title/:subject/:catalogNumber', async function (req, res) {
+  const subject = req.params.subject.toUpperCase();
+  const catalogNumber = req.params.catalogNumber;
+
+  const { err, title } = await courseListDB.getCourseTitle(subject, catalogNumber);
+  if (err) res.status(400).send(err);
+  else res.send(title);
+});
+
 // Get information about course
 CoursesRouter.get('/info/:subject/:catalogNumber', async function(req, res) {
   const subject = req.params.subject.toUpperCase();
   const catalogNumber = req.params.catalogNumber;
 
   // Get course information
-  let { err, course } = await courses.getCourseInfo(subject.toUpperCase(), catalogNumber);
-  if (err) return res.status(400).send(err);
-  if (course == null) return res.status(400).send('Course not found.');
-  const {
-    // academicLevel,
-    description,
-    crosslistings,
-    notes,
-    terms,
-    title,
-    units,
-    url,
-  } = course;
-
-  // Get course requisites
-  let reqs = null;
-  ({ err, reqs } = await requisitesDB.getRequisites(subject, catalogNumber));
-  if (err) res.status(400).send(err);
-
-  const prereqs = (reqs != null) ? reqs.prereqs : {};
-  const coreqs = (reqs != null) ? reqs.coreqs : [];
-  const antireqs = (reqs != null) ? reqs.antireqs : [];
-  let rating = null;
-
-  ({ err, rating } = await courseRatingsDB.getCourseRatings(subject, catalogNumber));
-  if (err) res.status(400).send(err);
-
-  const postreqs = (reqs != null) ? reqs.postreqs : {};
-
-  res.json({
-    description,
-    crosslistings: crosslistings || '',
-    notes: notes || '',
-    terms: terms || [],
-    title,
-    units,
-    url,
-    rating,
-    prereqs: prereqs || {},
-    coreqs: coreqs || [],
-    antireqs: antireqs || [],
-    postreqs: postreqs || {},
-  });
+  let { err, info } = await courses.getCourseInfo(subject.toUpperCase(), catalogNumber);
+  if (err) return res.status(400).send(err.message);
+  else res.json(info);
 });
 
 // Get classes for a course

--- a/server/routes/parse.js
+++ b/server/routes/parse.js
@@ -13,6 +13,7 @@ ParseRouter.post('/courses', function(req, res) {
   res.json(courses);
 });
 
+// Parse user's transcript into courses (fill up My Courses)
 ParseRouter.post('/transcript', function(req, res) {
   const transcript = parseTranscript(req.body.text);
   res.json(transcript);

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -240,7 +240,6 @@ UsersRouter.post('/set/courselist/:username', async function(req, res) {
   if (req.user !== username) return res.sendStatus(401);
 
   const courseList = await setCourseListPrereqs(req.body.courseList);
-  // console.log(courseList)
   const err = await users.setCourseList(username, courseList);
   if (err) {
     console.error(err);


### PR DESCRIPTION
# Description
1. Changes courseList database schema to store course title instead of just a boolean
2. Update course search to use courseList instead of courses (less overhead when calling Firebase)
3. Requisites table now show the title of the course
4. In "My Courses", course title will show on hover

Fixes #75, #49 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
