### PR TITLE
Add loading icon on register button

### DIFF
--- a/react-ui/src/components/login/Register.jsx
+++ b/react-ui/src/components/login/Register.jsx
@@ -4,6 +4,7 @@ import { toast } from 'react-toastify';
 import Paper from 'material-ui/Paper';
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
+import CircularProgress from 'material-ui/CircularProgress';
 import EmailSent from '../email/EmailSent';
 import {
   validateUsername,
@@ -56,8 +57,7 @@ const styles = {
     flex: 1,
   },
   registerButton: {
-    width: '100%',
-    marginTop: 20,
+    width: '100%'
   },
   registerText: {
     color: 'white',
@@ -70,6 +70,18 @@ const styles = {
   footer: {
     marginTop: 40,
     marginBottom: 20,
+  },
+  loadingIcon: {
+    color: green[500],
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    marginTop: -12,
+    marginLeft: -12
+  },
+  registerButtonWrapper: {
+    marginTop: 20,
+    position: 'relative'
   }
 };
 
@@ -77,6 +89,7 @@ export default class Register extends Component {
 
   state = {
     registered: false,
+    loading: false,
     usernameError: '',
     nameError: '',
     emailError: '',
@@ -116,6 +129,10 @@ export default class Register extends Component {
       }
     }
 
+    this.setState({
+      loading: true
+    });
+
     try {
       const response = await fetch('/server/auth/register', {
         method: 'POST',
@@ -153,7 +170,7 @@ export default class Register extends Component {
           return;
         }
       } else {
-        this.setState({ registered: true });
+        this.setState({ registered: true, loading: false });
       }
     } catch (err) {
       toast.error('Failed to create account. Please contact an administrator.');
@@ -210,14 +227,20 @@ export default class Register extends Component {
                 onChange={ this.removeErrors }
                 ref="confirmPassword"
               /><br />
-              <RaisedButton
-                label="Sign up"
-                backgroundColor={  green  }
-                style={ styles.registerButton }
-                labelStyle={ styles.registerText }
-                onClick={ this.onRegister }
-                type="submit"
-              />
+              <div style={ styles.registerButtonWrapper }>
+                <RaisedButton
+                  label="Sign up"
+                  backgroundColor={  green  }
+                  style={ styles.registerButton }
+                  labelStyle={ styles.registerText }
+                  onClick={ this.onRegister }
+                  disabled={ this.state.loading }
+                  type="submit"
+                />
+                {this.state.loading && 
+                  <CircularProgress size={ 24 } style={ styles.loadingIcon } />
+                }
+              </div>
             </form>
           </Paper>
           <div style={ styles.privacy }>


### PR DESCRIPTION
# Description

When a user submits the registration form, we want there to be some sort of indication that we are processing the request. There can be a loading icon in place of the "Sign Up" text in the submit button. This icon is a CircularProgress component from material-ui. I added a "loading" state property that toggles when user clicks sign up (button disabled). However, this only gets toggled if there are no errors detected from the inputs. 

Fixes # 64

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manually tested by filling the registration fields and clicking "Sign Up". The loading icon is displayed on top of the "Sign Up" text and the button is disabled for a duration before the async response is received. Clicking "Sign Up" with errors in the fields should not trigger the loading icon.

- [x] loading icon displays after "Sign Up" is clicked (no errors in the fields)
- [x] loading icon does not display after "Sign Up" is clicked (errors in the fields)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
