### PR TITLE
Fix 1 day view render

### DIFF
--- a/react-ui/src/components/schedule/calendar/DayView.js
+++ b/react-ui/src/components/schedule/calendar/DayView.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import verticalHours from './verticalHours';
 import renderDayEvents from './DayEvents';
@@ -21,11 +21,15 @@ const styles = {
     background: 'white',
     boxShadow: '0 14px 28px rgba(255,255,255,0.60), 0 10px 10px rgba(255,255,255,0.80)'
   },
-  hoursContainer: (isScrollDisable) => ({
+  bodyContainer: (isScrollDisable) => ({
     height: '100%',
     position: 'relative',
     overflowY: isScrollDisable ? 'hidden' : 'auto'
   }),
+  hoursContainer: {
+    height,
+    position: 'absolute'
+  },
   daysContainer: {
     height,
     position: 'absolute',
@@ -34,52 +38,63 @@ const styles = {
   }
 }
 
-const DayView = ({
-  date,
-  scrollPosition,
-  onScrollChange,
-  children,
-  isScrollDisable
-}) => (
-  <div style={ styles.container }>
-    <div
-      ref={ elem => {
-        if (elem != null) {
-          this.scrollViewer = elem;
-          elem.scrollTop = scrollPosition;
-        }
-      } }
-      onTouchStart={ (e) => setTimeout(() => onScrollChange(this.scrollViewer.scrollTop), 100) }
-      style={ styles.hoursContainer(isScrollDisable) }>
-      <div style={{ position: 'absolute', height: height + 'px' }}>
-        {
-          verticalHours()
-        }
-      </div>
-      <div
-        key="eventsContainer"
-        style={ styles.daysContainer }>
-        {
-          renderDayEvents({
-            events: children,
-            date
-          })
-        }
-      </div>
-    </div>
-    <DayHeader
-      style={ styles.dayHeader }
-      date={ date }
-    />
-  </div>
-);
+export default class DayView extends PureComponent {
+  static propTypes = {
+    date: PropTypes.object.isRequired,
+    scrollPosition: PropTypes.number.isRequired,
+    onScrollChange: PropTypes.func.isRequired,
+    children: PropTypes.array.isRequired,
+    isScrollDisable: PropTypes.bool.isRequired,
+  };
 
-DayView.propTypes = {
-  date: PropTypes.object.isRequired,
-  scrollPosition: PropTypes.number.isRequired,
-  onScrollChange: PropTypes.func.isRequired,
-  children: PropTypes.array.isRequired,
-  isScrollDisable: PropTypes.bool.isRequired,
+  constructor(props) {
+    super(props);
+    this.scrollViewer = React.createRef();
+  }
+
+  componentDidMount = () => {
+    this.scrollViewer.current.scrollTop = this.props.scrollPosition;
+  }
+
+  onScroll = () => {
+    const scrollPosition = this.scrollViewer.current.scrollTop;
+    this.props.onScrollChange(scrollPosition);
+  }
+
+  render() {
+    const {
+      date,
+      children,
+      isScrollDisable
+    } = this.props;
+
+    return (
+      <div style={ styles.container }>
+        <div
+          ref={ this.scrollViewer }
+          onScroll={ this.onScroll }
+          style={ styles.bodyContainer(isScrollDisable) }>
+          <div style={ styles.hoursContainer }>
+            {
+              verticalHours()
+            }
+          </div>
+          <div
+            key="eventsContainer"
+            style={ styles.daysContainer }>
+            {
+              renderDayEvents({
+                events: children,
+                date
+              })
+            }
+          </div>
+        </div>
+        <DayHeader
+          style={ styles.dayHeader }
+          date={ date }
+        />
+      </div>
+    );
+  }
 }
-
-export default DayView;

--- a/react-ui/src/components/schedule/calendar/MultipleDaysView.js
+++ b/react-ui/src/components/schedule/calendar/MultipleDaysView.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import verticalHours from './verticalHours';
 import renderDayEvents from './DayEvents';
@@ -100,7 +100,7 @@ const renderDays = (dates, children) => {
   ));
 }
 
-export default class MultipleDaysView extends Component {
+export default class MultipleDaysView extends PureComponent {
   static propTypes = {
     dates: PropTypes.array.isRequired,
     scrollPosition: PropTypes.number.isRequired,
@@ -109,11 +109,23 @@ export default class MultipleDaysView extends Component {
     children: PropTypes.node.isRequired
   };
 
+  constructor(props) {
+    super(props);
+    this.scrollViewer = React.createRef();
+  }
+
+  componentDidMount = () => {
+    this.scrollViewer.current.scrollTop = this.props.scrollPosition;
+  }
+
+  onScroll = () => {
+    const scrollPosition = this.scrollViewer.current.scrollTop;
+    this.props.onScrollChange(scrollPosition);
+  }
+
   render() {
     const {
       dates,
-      scrollPosition,
-      onScrollChange,
       isScrollDisable,
       children
     } = this.props;
@@ -127,13 +139,8 @@ export default class MultipleDaysView extends Component {
           }
         </div>
         <div
-          ref={ elem => {
-            if(elem != null) {
-              this.scrollViewer = elem;
-              elem.scrollTop = scrollPosition;
-            }
-          } }
-          onTouchStart={ (e) => setTimeout(() => onScrollChange(this.scrollViewer.scrollTop), 100) }
+          ref={ this.scrollViewer }
+          onScroll={ this.onScroll }
           style={ styles.bodyContainer(isScrollDisable) }>
           <div style={ styles.hoursContainer }>
             {


### PR DESCRIPTION
# Description

Mainly changed how [`refs`](https://reactjs.org/docs/refs-and-the-dom.html) are created and handled to fix a bug that prevented the `DayView` component from rendering.
Ended up converting `DayView` from a `Stateless Component` to a `PureComponent` so we could add lifecycle events and initialize the `scrollViewer` ref using `createRef`. Made a similar change to `MultipleDaysView` for consistency.
Then a little (maybe unnecessary?) refactoring. Created a couple TODOs that I can address in separate PRs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Manually tested by comparing local with version running [live](https://watsmymajor.com). Checked navigation, scrolling, and swiping in the `MySchedule` view.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
