### PR TITLE
Optimize courseboard

### DIFF
--- a/react-ui/src/components/mycourse/CourseBoardContainer.jsx
+++ b/react-ui/src/components/mycourse/CourseBoardContainer.jsx
@@ -115,7 +115,7 @@ class CourseBoardContainer extends Component {
     cart: PropTypes.array.isRequired,
     username: PropTypes.string.isRequired,
     updateCourseHandler: PropTypes.func.isRequired,
-    setCartHandler: PropTypes.func.isRequired,
+    updateCartHandler: PropTypes.func.isRequired,
     deselectCourseHandler: PropTypes.func.isRequired,
     highlightPrereqsHandler: PropTypes.func.isRequired,
     sendDuplicateCourseSnack: PropTypes.func.isRequired,
@@ -215,7 +215,7 @@ class CourseBoardContainer extends Component {
     const toIndex = destination.index + toRowNum * numPerRow - offsetNum;
 
     if (fromIndex === toIndex) return;
-    const { username, courseList } = this.state;
+    const { courseList } = this.state;
     const [removed] = courseList.splice(fromIndex, 1);
     courseList.splice(toIndex, 0, removed);
     this.setState({ courseList });
@@ -234,7 +234,7 @@ class CourseBoardContainer extends Component {
   getBoard = (id) => {
     switch (id) {
     case 'Cart':
-      return this.state.cart;
+      return this.state.cart.slice();
     case 'Trash':
       return null;
     default:
@@ -246,7 +246,9 @@ class CourseBoardContainer extends Component {
         `);
         toast.error('There was an error updating your courses.  Please contact an administrator.');
       }
-      return this.state.courseList[id].courses || [];
+      if (this.state.courseList[id].courses != null) {
+        return this.state.courseList[id].courses.slice();
+      } else return [];
     }
   }
 
@@ -324,10 +326,7 @@ class CourseBoardContainer extends Component {
     this.setState({ courseList });
   }
 
-  clearCart = () => {
-    this.setState({ cart: [] });
-    this.props.setCartHandler(this.state.username, []);
-  }
+  clearCart = () => this.setState({ cart: [] });
 
   addBoard = (term, level) => {
     const { courseList } = this.state;
@@ -412,7 +411,7 @@ class CourseBoardContainer extends Component {
   }
 
   deleteBoard = (id) => {
-    const { username, courseList } = this.state;
+    const { courseList } = this.state;
     courseList.splice(id, 1);
     this.setState({ courseList });
   }
@@ -420,8 +419,9 @@ class CourseBoardContainer extends Component {
   toggleEditing = (isEditing) => {
     // Save board
     if (!isEditing) {
-      const { username, courseList } = this.state;
+      const { username, courseList, cart } = this.state;
       this.props.updateCourseHandler(username, courseList);
+      this.props.updateCartHandler(username, cart);
     }
     this.setState({ isEditing });
   }
@@ -588,7 +588,7 @@ const mapDispatchToProps = dispatch => {
     updateCourseHandler: (username, courseList) => {
       dispatch(updateUserCourses(username, courseList));
     },
-    setCartHandler: (username, cart) => {
+    updateCartHandler: (username, cart) => {
       dispatch(setCart(username, cart));
     },
     deselectCourseHandler: () => {

--- a/react-ui/src/components/mycourse/MyCourseAppBar.jsx
+++ b/react-ui/src/components/mycourse/MyCourseAppBar.jsx
@@ -9,6 +9,8 @@ import RaisedButton from 'material-ui/RaisedButton';
 import SelectField from 'material-ui/SelectField';
 import TextField from 'material-ui/TextField';
 import AddIcon from 'material-ui/svg-icons/content/add';
+import EditIcon from 'material-ui/svg-icons/image/edit';
+import SaveIcon from 'material-ui/svg-icons/content/save';
 import ImportIcon from 'material-ui/svg-icons/action/backup';
 import ClearIcon from 'material-ui/svg-icons/content/clear';
 import Parser from './ParseTranscript';
@@ -17,6 +19,7 @@ import {
   skyBlue,
   red,
   lightGreen2,
+  blueGreenHighlight,
 } from 'constants/Colours';
 
 const styles = {
@@ -68,9 +71,11 @@ export default class MyCourseAppBar extends Component {
     onAddBoard: PropTypes.func.isRequired,
     onImport: PropTypes.func.isRequired,
     onClear: PropTypes.func.isRequired,
+    onEditChange: PropTypes.func.isRequired,
     showClearButton: PropTypes.bool.isRequired,
     showTrashOnDrag: PropTypes.bool,
     isDraggingCourse: PropTypes.bool,
+    isEditing: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -137,7 +142,17 @@ export default class MyCourseAppBar extends Component {
     this.props.onClear();
   }
 
+  onEditOn = () => this.props.onEditChange(true);
+  onEditOff = () => this.props.onEditChange(false);
+
   render() {
+    const {
+      showTrashOnDrag,
+      isDraggingCourse,
+      showClearButton,
+      isEditing,
+    } = this.props;
+
     const addTermDialogActions = [
       <FlatButton
         label="Cancel"
@@ -175,11 +190,11 @@ export default class MyCourseAppBar extends Component {
       />,
     ];
 
-    const showTrash = (this.props.showTrashOnDrag && this.props.isDraggingCourse);
+    const showTrash = (showTrashOnDrag && isDraggingCourse);
 
     return (
       <div style={ styles.container }>
-        { this.props.showTrashOnDrag && (
+        { showTrashOnDrag && (
           <div style={ styles.trashContainer(showTrash) }>
             <Trash isMobile />
           </div>
@@ -197,13 +212,17 @@ export default class MyCourseAppBar extends Component {
               <MediaQuery minWidth={ 852 }>
                 { matches => (
                   <div>
-                    <RaisedButton
-                      onClick={ this.openAddTermDialog }
-                      label="Add Term"
-                      backgroundColor={ lightGreen2 }
-                      style={ styles.button(matches) }
-                      icon={ <AddIcon /> }
-                    />
+                    {
+                      isEditing && (
+                        <RaisedButton
+                          onClick={ this.openAddTermDialog }
+                          label="Add Term"
+                          backgroundColor={ lightGreen2 }
+                          style={ styles.button(matches) }
+                          icon={ <AddIcon /> }
+                        />
+                      )
+                    }
                     <RaisedButton
                       onClick={ this.openImportDialog }
                       label="Import Courses"
@@ -212,7 +231,7 @@ export default class MyCourseAppBar extends Component {
                       icon={ <ImportIcon /> }
                     />
                     {
-                      this.props.showClearButton && (
+                      isEditing && showClearButton && (
                         <RaisedButton
                           onClick={ this.openClearDialog }
                           label="Clear Board"
@@ -221,6 +240,27 @@ export default class MyCourseAppBar extends Component {
                           icon={ <ClearIcon /> }
                         />
                       )
+                    }
+                    {
+                      isEditing
+                        ? (
+                          <RaisedButton
+                            onClick={ this.onEditOff }
+                            label="Save Board"
+                            backgroundColor={ blueGreenHighlight }
+                            style={ styles.button(matches) }
+                            icon={ <SaveIcon /> }
+                          />
+                        )
+                        : (
+                          <RaisedButton
+                            onClick={ this.onEditOn }
+                            label="Edit Board"
+                            backgroundColor={ lightGreen2 }
+                            style={ styles.button(matches) }
+                            icon={ <EditIcon /> }
+                          />
+                        )
                     }
                   </div>
                 ) }
@@ -240,7 +280,7 @@ export default class MyCourseAppBar extends Component {
                 icon={ <ImportIcon /> }
               />
               {
-                this.props.showClearButton && (
+                showClearButton && (
                   <RaisedButton
                     onClick={ this.openClearDialog }
                     backgroundColor={ red }

--- a/react-ui/src/components/mycourse/MyCourseAppBar.jsx
+++ b/react-ui/src/components/mycourse/MyCourseAppBar.jsx
@@ -2,9 +2,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import MediaQuery from 'react-responsive';
 import { toast } from 'react-toastify';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import IconButton from '@material-ui/core/IconButton';
 import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
-import MenuItem from 'material-ui/MenuItem';
 import RaisedButton from 'material-ui/RaisedButton';
 import SelectField from 'material-ui/SelectField';
 import TextField from 'material-ui/TextField';
@@ -12,7 +14,9 @@ import AddIcon from 'material-ui/svg-icons/content/add';
 import EditIcon from 'material-ui/svg-icons/image/edit';
 import SaveIcon from 'material-ui/svg-icons/content/save';
 import ImportIcon from 'material-ui/svg-icons/action/backup';
-import ClearIcon from 'material-ui/svg-icons/content/clear';
+import CloseIcon from 'material-ui/svg-icons/navigation/close';
+import ClearIcon from 'material-ui/svg-icons/navigation/refresh';
+import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import Parser from './ParseTranscript';
 import Trash from './Trash';
 import {
@@ -20,6 +24,7 @@ import {
   red,
   lightGreen2,
   blueGreenHighlight,
+  mustard,
 } from 'constants/Colours';
 
 const styles = {
@@ -90,6 +95,7 @@ export default class MyCourseAppBar extends Component {
     text: '',
     level: '1A',
     errorText: '',
+    menuEl: null,
   };
 
   openAddTermDialog = () => this.setState({ addTermDialogOpen: true });
@@ -102,6 +108,9 @@ export default class MyCourseAppBar extends Component {
 
   onChangeText = (_, text) => this.setState({ text, errorText: '' });
   onChangeLevel = (ev, index, level) => this.setState({ level });
+
+  openMenu = (ev) => this.setState({ menuEl: ev.currentTarget });
+  closeMenu = (ev) => this.setState({ menuEl: null });
 
   onAddTerm = () => {
     const { text, level } = this.state;
@@ -144,6 +153,7 @@ export default class MyCourseAppBar extends Component {
 
   onEditOn = () => this.props.onEditChange(true);
   onEditOff = () => this.props.onEditChange(false);
+  onCancel = () => this.props.onEditChange(false, true);
 
   render() {
     const {
@@ -235,7 +245,7 @@ export default class MyCourseAppBar extends Component {
                         <RaisedButton
                           onClick={ this.openClearDialog }
                           label="Clear Board"
-                          backgroundColor={ red }
+                          backgroundColor={ mustard }
                           style={ styles.button(matches) }
                           icon={ <ClearIcon /> }
                         />
@@ -246,7 +256,7 @@ export default class MyCourseAppBar extends Component {
                         ? (
                           <RaisedButton
                             onClick={ this.onEditOff }
-                            label="Save Board"
+                            label="Save"
                             backgroundColor={ blueGreenHighlight }
                             style={ styles.button(matches) }
                             icon={ <SaveIcon /> }
@@ -262,33 +272,75 @@ export default class MyCourseAppBar extends Component {
                           />
                         )
                     }
+                    {
+                      isEditing && (
+                        <RaisedButton
+                          onClick={ this.onCancel }
+                          label="Cancel"
+                          backgroundColor={ red }
+                          style={ styles.button(matches) }
+                          icon={ <CloseIcon /> }
+                        />
+                      )
+                    }
                   </div>
                 ) }
               </MediaQuery>
             </MediaQuery>
             <MediaQuery maxWidth={ 821 }>
-              <RaisedButton
-                onClick={ this.openAddTermDialog }
-                backgroundColor={ lightGreen2 }
-                style={ styles.xsButton }
-                icon={ <AddIcon /> }
-              />
-              <RaisedButton
-                onClick={ this.openImportDialog }
-                backgroundColor={ skyBlue }
-                style={ styles.xsButton }
-                icon={ <ImportIcon /> }
-              />
-              {
-                showClearButton && (
-                  <RaisedButton
-                    onClick={ this.openClearDialog }
-                    backgroundColor={ red }
-                    style={ styles.xsButton }
-                    icon={ <ClearIcon /> }
-                  />
-                )
-              }
+              <IconButton
+                aria-label="more"
+                aria-controls="long-menu"
+                aria-haspopup="true"
+                onClick={ this.openMenu }
+              >
+                <MoreVertIcon />
+              </IconButton>
+              <Menu
+                id="long-menu"
+                anchorEl={ this.state.menuEl }
+                keepMounted
+                open={ this.state.menuEl != null }
+                onClose={ this.closeMenu }
+              >
+                {
+                  isEditing && (
+                    <MenuItem onClick={ this.openAddTermDialog }>
+                      Add Term
+                    </MenuItem>
+                  )
+                }
+                <MenuItem onClick={ this.openImportDialog }>
+                  Import Courses
+                </MenuItem>
+                {
+                  isEditing && showClearButton && (
+                    <MenuItem onClick={ this.openClearDialog }>
+                      Clear Board
+                    </MenuItem>
+                  )
+                }
+                {
+                  isEditing
+                    ? (
+                      <MenuItem onClick={ this.onEditOff }>
+                        Save Changes
+                      </MenuItem>
+                    )
+                    : (
+                      <MenuItem onClick={ this.onEditOn }>
+                        Edit Board
+                      </MenuItem>
+                    )
+                }
+                {
+                  isEditing && (
+                    <MenuItem onClick={ this.onCancel }>
+                      Discard Changes
+                    </MenuItem>
+                  )
+                }
+              </Menu>
             </MediaQuery>
           </div>
           <div>

--- a/react-ui/src/components/mycourse/MyCourseSideBar.jsx
+++ b/react-ui/src/components/mycourse/MyCourseSideBar.jsx
@@ -7,21 +7,24 @@ const styles = {
   container: {
     position: 'fixed',
     right: 0,
-    paddingTop: 30,
-    paddingRight: 30,
+    marginTop: 30,
+    marginRight: 30,
     display: 'flex',
     flexDirection: 'column',
   },
 };
 
-const MyCourseSideBar = ({ cartCourses, onClearCart }) => (
+const MyCourseSideBar = ({ cartCourses, onClearCart, isEditing }) => (
   <div style={ styles.container }>
-    <Trash />
+    {
+      isEditing && <Trash />
+    }
     <TermBoard
       term="Cart"
       courses={ cartCourses }
       isCart
       onClearBoard={ onClearCart }
+      isEditing={ isEditing }
     />
   </div>
 );
@@ -29,6 +32,7 @@ const MyCourseSideBar = ({ cartCourses, onClearCart }) => (
 MyCourseSideBar.propTypes = {
   cartCourses: PropTypes.array,
   onClearCart: PropTypes.func,
+  isEditing: PropTypes.bool.isRequired,
 };
 
 MyCourseSideBar.defaultProps = {

--- a/react-ui/src/components/mycourse/ParseTranscript.jsx
+++ b/react-ui/src/components/mycourse/ParseTranscript.jsx
@@ -21,10 +21,12 @@ const ParseTranscript = ({ onChange }) => {
       text: (
         <div style={{ textAlign: 'center' }}>
           <p>
-            Select all, copy, and paste it below.
+            Select and copy everything
           </p>
           <p>
-            If that doesn't work, right-click, select "Print", and copy everything within the preview screen.
+            <i>
+              If that doesn't work, right-click, select "Print", and copy everything within the preview screen.
+            </i>
           </p>
         </div>
       )

--- a/react-ui/src/components/mycourse/TermBoard.jsx
+++ b/react-ui/src/components/mycourse/TermBoard.jsx
@@ -141,7 +141,7 @@ export default class TermBoard extends Component {
     isEditing: PropTypes.bool.isRequired,
     isCart: PropTypes.bool,
     onRenameBoard: PropTypes.func,
-    onUpdateCourses: PropTypes.func,
+    onAddCourses: PropTypes.func,
     onDeleteBoard: PropTypes.func,
     onClearBoard: PropTypes.func.isRequired,
   };
@@ -154,7 +154,7 @@ export default class TermBoard extends Component {
     provided: {},
     snapshot: {},
     isCart: false,
-    onUpdateCourses: () => null,
+    onAddCourses: () => null,
     onRenameBoard: () => null,
   };
 
@@ -233,12 +233,12 @@ export default class TermBoard extends Component {
     }).then((termCourses) => {
       this.setState({ importing: false });
       const { courses } = termCourses;
-      this.props.onUpdateCourses(courses);
+      this.props.onAddCourses(courses);
     }).catch(err => toast.error(`Failed to parse your courses. Error: ${err.message}`));
   }
 
   onSearchResult = ({ subject, catalogNumber }) => {
-    this.props.onUpdateCourses([{ subject, catalogNumber }])
+    this.props.onAddCourses([{ subject, catalogNumber }])
     this.closeAddDialog();
   }
 

--- a/react-ui/src/components/mycourse/TermBoard.jsx
+++ b/react-ui/src/components/mycourse/TermBoard.jsx
@@ -28,12 +28,13 @@ const stylesConst = {
   width: 200,
 };
 const styles = {
-  board: {
+  board: (isCart) => ({
     margin: 10,
     width:  stylesConst.width,
     display: 'flex',
     flexDirection: 'column',
-  },
+    maxHeight: (isCart) ? 450 : 'none',
+  }),
   header: (isDragging) => ({
     padding: '5px 0',
     backgroundColor: isDragging ? lightPurple : purple,
@@ -61,10 +62,10 @@ const styles = {
     color: 'white',
     marginLeft: 'auto'
   },
-  listContainer: {
-    height: 'calc(100% - 70px)',
+  listContainer: (isCart) => ({
     margin: '6px 0',
-  },
+    overflowY: (isCart) ? 'auto' : 'none',
+  }),
   addCourseCard: {
     border: '1px dashed #bcbcbc',
     borderRadius: '5px',
@@ -99,7 +100,7 @@ AddCourseCard.propTypes = {
   onClick: PropTypes.func.isRequired,
 };
 
-const renderCourses = (showAdd, courseList, onClick, highlightBackground) => {
+const renderCourses = (showAdd, isEditing, courseList, onClick, highlightBackground) => {
   const courses = courseList.map((course, index) => {
     if (course == null) return null; // Not sure why it would be null, but err was thrown
     const key = `${course.subject}/${course.catalogNumber}/${index}`;
@@ -109,6 +110,7 @@ const renderCourses = (showAdd, courseList, onClick, highlightBackground) => {
         draggableId={ key }
         index={ index }
         type={ DragTypes.COURSE }
+        isDragDisabled={ !isEditing }
       >
         { (provided, snapshot) => (
           <CourseCard
@@ -121,8 +123,8 @@ const renderCourses = (showAdd, courseList, onClick, highlightBackground) => {
       </Draggable>
     );
   });
-  // Add "Add courses" button if not a cart
-  if (showAdd) courses.push(<AddCourseCard key='add-course' onClick={ onClick } />);
+  // Add "Add courses" button if not a cart and editing mode is on
+  if (showAdd && isEditing) courses.push(<AddCourseCard key='add-course' onClick={ onClick } />);
   return courses;
 };
 
@@ -135,6 +137,7 @@ export default class TermBoard extends Component {
     courses: PropTypes.array,
     provided: PropTypes.object,
     snapshot: PropTypes.object,
+    isEditing: PropTypes.bool.isRequired,
     isCart: PropTypes.bool,
     onRenameBoard: PropTypes.func,
     onUpdateCourses: PropTypes.func,
@@ -233,7 +236,7 @@ export default class TermBoard extends Component {
   }
 
   render() {
-    const { index, term, level, courses, isCart } = this.props;
+    const { index, term, level, courses, isCart, isEditing } = this.props;
     const droppableId = (isCart) ? 'Cart' : index;
 
     const renameDialogActions = [
@@ -287,7 +290,7 @@ export default class TermBoard extends Component {
       <div ref={ innerRef } { ...draggableProps }>
         <Paper
           zDepth={ 1 }
-          style={ styles.board }
+          style={ styles.board(isCart) }
         >
           <div style={ styles.header(isDragging) } { ...dragHandleProps }>
             <div style={ styles.box } />
@@ -298,31 +301,35 @@ export default class TermBoard extends Component {
               ) }
             </div>
             <div style={ styles.box } >
-              <IconMenu
-                iconButtonElement={ <IconButton><MoreVertIcon /></IconButton> }
-                anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
-                targetOrigin={{ horizontal: 'left', vertical: 'top' }}
-                iconStyle={ styles.editIcon }
-                onRequestChange={ this.toggleSettings }
-                open={ this.state.settingsOpen }
-                useLayerForClickAway
-              >
-                {
-                  isCart
-                    ? <MenuItem primaryText="Clear Cart" onClick={ this.clearBoard } />
-                    : (
-                      <div>
-                        <MenuItem primaryText="Edit Name" onClick={ this.openRenameDialog } />
-                        <MenuItem primaryText="Import Courses" onClick={ this.openImportDialog } />
-                        <MenuItem primaryText="Clear Term" onClick={ this.clearBoard } />
-                        <MenuItem primaryText="Delete Term" onClick={ this.deleteBoard } />
-                      </div>
-                    )
-                }
-              </IconMenu>
+              {
+                isEditing && (
+                  <IconMenu
+                    iconButtonElement={ <IconButton><MoreVertIcon /></IconButton> }
+                    anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
+                    targetOrigin={{ horizontal: 'left', vertical: 'top' }}
+                    iconStyle={ styles.editIcon }
+                    onRequestChange={ this.toggleSettings }
+                    open={ this.state.settingsOpen }
+                    useLayerForClickAway
+                  >
+                    {
+                      isCart
+                        ? <MenuItem primaryText="Clear Cart" onClick={ this.clearBoard } />
+                        : (
+                          <div>
+                            <MenuItem primaryText="Edit Name" onClick={ this.openRenameDialog } />
+                            <MenuItem primaryText="Import Courses" onClick={ this.openImportDialog } />
+                            <MenuItem primaryText="Clear Term" onClick={ this.clearBoard } />
+                            <MenuItem primaryText="Delete Term" onClick={ this.deleteBoard } />
+                          </div>
+                        )
+                    }
+                  </IconMenu>
+                )
+              }
             </div>
           </div>
-          <div style={ styles.listContainer }>
+          <div style={ styles.listContainer(isCart) }>
             <Droppable
               droppableId={ droppableId }
               type={ DragTypes.COURSE }
@@ -332,7 +339,7 @@ export default class TermBoard extends Component {
                   ref={ provided.innerRef }
                   style={ getListStyle(snapshot.isDraggingOver) }
                 >
-                  { renderCourses(!isCart && !snapshot.isDraggingOver, courses, this.openAddDialog, snapshot.isDraggingOver) }
+                  { renderCourses(!isCart && !snapshot.isDraggingOver, isEditing, courses, this.openAddDialog, snapshot.isDraggingOver) }
                   { provided.placeholder }
                 </div>
               ) }

--- a/react-ui/src/components/mycourse/TermRow.jsx
+++ b/react-ui/src/components/mycourse/TermRow.jsx
@@ -20,9 +20,10 @@ const TermRow = ({
   onRenameBoard,
   onDeleteBoard,
   onUpdateCourses,
-  showCart,
   cart,
   onClearCart,
+  isEditing,
+  showCart,
 }) => (
   <Droppable
     droppableId={ `row/${rowNumber}` }
@@ -40,8 +41,9 @@ const TermRow = ({
           <TermBoard
             term="Cart"
             courses={ cart }
-            isCart
             onClearBoard={ onClearCart }
+            isEditing={ isEditing }
+            isCart
           />
         ) }
         {
@@ -54,6 +56,7 @@ const TermRow = ({
                 type={ DragTypes.COLUMN }
                 index={ index }
                 key={ index }
+                isDragDisabled={ !isEditing }
               >
                 { (provided, snapshot) => (
                   <TermBoard
@@ -63,6 +66,7 @@ const TermRow = ({
                     courses={ courses }
                     provided={ provided }
                     snapshot={ snapshot }
+                    isEditing={ isEditing }
                     onClearBoard={ () => onClearBoard(offsetIndex) }
                     onRenameBoard={ (rename, relevel) => onRenameBoard(offsetIndex, rename, relevel) }
                     onDeleteBoard={ () => onDeleteBoard(offsetIndex) }
@@ -86,6 +90,7 @@ TermRow.propTypes = {
   onRenameBoard: PropTypes.func.isRequired,
   onDeleteBoard: PropTypes.func.isRequired,
   onUpdateCourses: PropTypes.func.isRequired,
+  isEditing: PropTypes.bool.isRequired,
   showCart: PropTypes.bool,
   cart: PropTypes.array,
   onClearCart: PropTypes.func,

--- a/react-ui/src/components/mycourse/TermRow.jsx
+++ b/react-ui/src/components/mycourse/TermRow.jsx
@@ -19,7 +19,7 @@ const TermRow = ({
   onClearBoard,
   onRenameBoard,
   onDeleteBoard,
-  onUpdateCourses,
+  onAddCourses,
   cart,
   onClearCart,
   isEditing,
@@ -70,7 +70,7 @@ const TermRow = ({
                     onClearBoard={ () => onClearBoard(offsetIndex) }
                     onRenameBoard={ (rename, relevel) => onRenameBoard(offsetIndex, rename, relevel) }
                     onDeleteBoard={ () => onDeleteBoard(offsetIndex) }
-                    onUpdateCourses={ (courses) => onUpdateCourses(offsetIndex, courses) }
+                    onAddCourses={ (courses) => onAddCourses(offsetIndex, courses) }
                   />
                 ) }
               </Draggable>
@@ -89,7 +89,7 @@ TermRow.propTypes = {
   onClearBoard: PropTypes.func.isRequired,
   onRenameBoard: PropTypes.func.isRequired,
   onDeleteBoard: PropTypes.func.isRequired,
-  onUpdateCourses: PropTypes.func.isRequired,
+  onAddCourses: PropTypes.func.isRequired,
   isEditing: PropTypes.bool.isRequired,
   showCart: PropTypes.bool,
   cart: PropTypes.array,

--- a/server/core/users.js
+++ b/server/core/users.js
@@ -82,6 +82,7 @@ async function setSchedulePrivacy(username, isPublic) {
 
 async function setCourseList(username, courseList) {
   try {
+    console.log('rearranging course list')
     const strippedCourseList = stripCourseListMetadata(courseList);
     await usersDB.setField(username, 'courseList', strippedCourseList);
     courseList = await fillCourseListMetadata(courseList);

--- a/server/core/users.js
+++ b/server/core/users.js
@@ -82,7 +82,6 @@ async function setSchedulePrivacy(username, isPublic) {
 
 async function setCourseList(username, courseList) {
   try {
-    console.log('rearranging course list')
     const strippedCourseList = stripCourseListMetadata(courseList);
     await usersDB.setField(username, 'courseList', strippedCourseList);
     courseList = await fillCourseListMetadata(courseList);

--- a/server/core/utils.js
+++ b/server/core/utils.js
@@ -177,6 +177,7 @@ async function fillCoursesMetadata(courses) {
 
     // Fill prereqs
     if (prereqs == null || prereqs.length === 0) {
+      // console.log('fill prereqs')
       let reqs = {};
       ({ err, reqs } = await getPrereqs(subject, catalogNumber));
       if (err) {
@@ -190,6 +191,7 @@ async function fillCoursesMetadata(courses) {
 
     // Fill course title
     if (title == null || title === '') {
+      // console.log('fill title')
       ({ err, title } = await getCourseTitle(subject, catalogNumber));
       if (err) {
         console.error(err);


### PR DESCRIPTION
# Description

In this PR, we want to reduce the number of database accesses when a user uses the course board feature.  Previously, we were updating the database with the whole course list whenever a user updates the course board.  However, this was way too expensive for such simple operations.

The (simple) fix for this is to implement an "edit mode" where the user can edit their courses to their pleasure.  We only send the updated course board once the user clicks "save".  Thus, we only make one database access.

Fixes #151 

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
