### PR TITLE
Fix blank term levels in Add term modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "WatsMyMajor",
+  "name": "watsmymajor",
   "version": "1.0.0",
   "description": "A web app that helps Waterloo students pick their courses",
   "engines": {

--- a/react-ui/src/components/mycourse/MyCourseAppBar.jsx
+++ b/react-ui/src/components/mycourse/MyCourseAppBar.jsx
@@ -9,6 +9,7 @@ import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import SelectField from 'material-ui/SelectField';
+import SelectMenuItem from 'material-ui/MenuItem';
 import TextField from 'material-ui/TextField';
 import AddIcon from 'material-ui/svg-icons/content/add';
 import EditIcon from 'material-ui/svg-icons/image/edit';
@@ -363,15 +364,15 @@ export default class MyCourseAppBar extends Component {
                 value={ this.state.level }
                 onChange={ this.onChangeLevel }
               >
-                <MenuItem value="1A" primaryText="1A" />
-                <MenuItem value="1B" primaryText="1B" />
-                <MenuItem value="2A" primaryText="2A" />
-                <MenuItem value="2B" primaryText="2B" />
-                <MenuItem value="3A" primaryText="3A" />
-                <MenuItem value="3B" primaryText="3B" />
-                <MenuItem value="4A" primaryText="4A" />
-                <MenuItem value="4B" primaryText="4B" />
-                <MenuItem value="5A+" primaryText="5A+" />
+                <SelectMenuItem value="1A" primaryText="1A" />
+                <SelectMenuItem value="1B" primaryText="1B" />
+                <SelectMenuItem value="2A" primaryText="2A" />
+                <SelectMenuItem value="2B" primaryText="2B" />
+                <SelectMenuItem value="3A" primaryText="3A" />
+                <SelectMenuItem value="3B" primaryText="3B" />
+                <SelectMenuItem value="4A" primaryText="4A" />
+                <SelectMenuItem value="4B" primaryText="4B" />
+                <SelectMenuItem value="5A+" primaryText="5A+" />
               </SelectField>
             </Dialog>
             <Dialog


### PR DESCRIPTION
# Description

This PR imports `material-ui/MenuItem` which is needed by the term levels. The new `@material-ui/core/MenuItem` is incompatible with our current implementation.

Fixes #166 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
